### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/deps/libuv/gyp_uv.py
+++ b/deps/libuv/gyp_uv.py
@@ -79,14 +79,14 @@ if __name__ == '__main__':
       args.extend(['-Goutput_dir=' + output_dir])
       args.extend(['--generator-output', output_dir])
     (major, minor), is_clang = compiler_version()
-    args.append('-Dgcc_version=%d' % (10 * major + minor))
-    args.append('-Dclang=%d' % int(is_clang))
+    args.append('-Dgcc_version={0:d}'.format((10 * major + minor)))
+    args.append('-Dclang={0:d}'.format(int(is_clang)))
 
   if not any(a.startswith('-Dhost_arch=') for a in args):
-    args.append('-Dhost_arch=%s' % host_arch())
+    args.append('-Dhost_arch={0!s}'.format(host_arch()))
 
   if not any(a.startswith('-Dtarget_arch=') for a in args):
-    args.append('-Dtarget_arch=%s' % host_arch())
+    args.append('-Dtarget_arch={0!s}'.format(host_arch()))
 
   if not any(a.startswith('-Duv_library=') for a in args):
     args.append('-Duv_library=static_library')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:libsourcey?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:libsourcey?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
